### PR TITLE
Se quitan las variables de nacidasEnTurno y muertasEnTuno de TurnoTab…

### DIFF
--- a/src/DatosTablero.cpp
+++ b/src/DatosTablero.cpp
@@ -18,16 +18,20 @@ DatosTablero::DatosTablero() {
 	this->turnosCongelado = 0;
 	this->numeroTurno = 0;
 	this->congeladoTurnoActual = true;
+	this->nacidasEnUltimoTurno = 0;
+	this->muertasEnUltimoTurno = 0;
 }
 
 unsigned int DatosTablero::getCantidadCelulasVivas(){
 	return this->cantidadCelulasVivas;
 }
 void DatosTablero::sumarCelulaViva(){
+	this->nacidasEnUltimoTurno ++;
 	this->cantidadCelulasVivas ++;
 	this->nacidasTotal ++;
 }
 void DatosTablero::sumarCelulaMuerta(){
+	this->muertasEnUltimoTurno ++;
 	this->cantidadCelulasVivas --;
 	this->muertasTotal ++;
 }
@@ -68,4 +72,17 @@ unsigned int DatosTablero::getTurno(){
 
 void DatosTablero::avanzarUnTurno(){
 	this->numeroTurno ++;
+}
+
+unsigned int DatosTablero::getNacidasEnUltimoTurno(){
+	return this->nacidasEnUltimoTurno;
+}
+
+unsigned int DatosTablero::getMuertasEnUltimoTurno(){
+	return this->muertasEnUltimoTurno;
+}
+
+void DatosTablero::reiniciarContadorNacidasMuertasEnUltimoTurno(){
+	this->nacidasEnUltimoTurno = 0;
+	this->muertasEnUltimoTurno = 0;
 }

--- a/src/DatosTablero.cpp
+++ b/src/DatosTablero.cpp
@@ -7,8 +7,6 @@
 
 #include "DatosTablero.h"
 
-#include "DatosTablero.h"
-
 DatosTablero::DatosTablero() {
 	this->cantidadCelulasVivas = 0;
 	this->muertasTotal = 0;

--- a/src/DatosTablero.h
+++ b/src/DatosTablero.h
@@ -18,6 +18,8 @@ private:
 	unsigned int turnosCongelado;
 	bool congeladoTurnoActual;
 	unsigned int numeroTurno;
+	unsigned int nacidasEnUltimoTurno;
+	unsigned int muertasEnUltimoTurno;
 
 public:
 	/*
@@ -93,5 +95,23 @@ public:
 	 * post: se suma uno al numero de turnos
 	 */
 	void avanzarUnTurno();
+
+	/*
+	 * pre: -
+	 * post: devuelve el numero de celulas que han nacido en el ultimo turno
+	 */
+	unsigned int getNacidasEnUltimoTurno();
+
+	/*
+	 * pre: -
+	 * post: devuelve el numero de celulas han muerto en el ultimo turno
+	 */
+	unsigned int getMuertasEnUltimoTurno();
+
+	/*
+	 * pre: -
+	 * post: Reinicia el contador de nacidasEnUltimoTurno y muertesEnUltimoTurno
+	 */
+	void reiniciarContadorNacidasMuertasEnUltimoTurno();
 };
 #endif /* SRC_DATOSTABLERO_H_ */

--- a/src/DatosTablero.h
+++ b/src/DatosTablero.h
@@ -109,7 +109,8 @@ public:
 	unsigned int getMuertasEnUltimoTurno();
 
 	/*
-	 * pre: -
+	 * pre: cada vez que se itera un turno en la clase Datostablero se almacena la informacion de las celulas nacidas y muertas en
+	 * el turno, por eso hace falta un metodo que las resetee a cero cada vez que se comienza un nuevo turno
 	 * post: Reinicia el contador de nacidasEnUltimoTurno y muertesEnUltimoTurno
 	 */
 	void reiniciarContadorNacidasMuertasEnUltimoTurno();

--- a/src/TurnoTablero.cpp
+++ b/src/TurnoTablero.cpp
@@ -92,7 +92,6 @@ void TurnoTablero::concretarCambios(){
 		}
 		else{
 			CambioARealizar->getParcela().getCelula()->morir();
-			//this->celulasMuertasTurno ++;
 			this->tableroAsociado->getDatosTablero()->sumarCelulaMuerta();
 		}
 		if (CambioARealizar->hayPortal()){

--- a/src/TurnoTablero.cpp
+++ b/src/TurnoTablero.cpp
@@ -10,8 +10,6 @@
 const int MAX_CANTIDAD_CELULAS_CIRCUNDANTES = 3;
 
 TurnoTablero::TurnoTablero(Tablero* tableroAsociado){
-	this->celulasMuertasTurno = 0;
-	this->celulasNacidasTurno = 0;
 	this->tableroAsociado = tableroAsociado;
 }
 
@@ -90,12 +88,12 @@ void TurnoTablero::concretarCambios(){
 		if (CambioARealizar->naceLaCelula()){
 			float factorNacimientoParcela = CambioARealizar->getParcela().getfactorNacimiento();
 			CambioARealizar->getParcela().getCelula()->nacer(factorNacimientoParcela, CambioARealizar->getColorPromedio());
-			this->celulasNacidasTurno ++;
+			//this->celulasNacidasTurno ++;
 			this->tableroAsociado->getDatosTablero()->sumarCelulaViva();
 		}
 		else{
 			CambioARealizar->getParcela().getCelula()->morir();
-			this->celulasMuertasTurno ++;
+			//this->celulasMuertasTurno ++;
 			this->tableroAsociado->getDatosTablero()->sumarCelulaMuerta();
 		}
 		if (CambioARealizar->hayPortal()){
@@ -103,7 +101,8 @@ void TurnoTablero::concretarCambios(){
 		}
 
 	}
-	if(this->celulasNacidasTurno != 0 || this->celulasMuertasTurno != 0){
+	if(this->tableroAsociado->getDatosTablero()->getNacidasEnUltimoTurno() != 0 ||
+			this->tableroAsociado->getDatosTablero()->getMuertasEnUltimoTurno() != 0){
 		this->tableroAsociado->getDatosTablero()->setCongeladoTurnoActual(false);
 	}
 }
@@ -111,14 +110,6 @@ void TurnoTablero::concretarCambios(){
 void TurnoTablero::plasmarCambiosEnArchivo(){
 	this->tableroAsociado->generarBMP();
 	this->tableroAsociado->guardarBMP(this->tableroAsociado->getDatosTablero()->getTurno());
-}
-
-unsigned int TurnoTablero::getNacidasEnTurno(){
-	return this->celulasNacidasTurno;
-}
-
-unsigned int TurnoTablero::getMuertasEnTurno(){
-	return this->celulasMuertasTurno;
 }
 
 void TurnoTablero::jugarTurno(){

--- a/src/TurnoTablero.cpp
+++ b/src/TurnoTablero.cpp
@@ -88,7 +88,6 @@ void TurnoTablero::concretarCambios(){
 		if (CambioARealizar->naceLaCelula()){
 			float factorNacimientoParcela = CambioARealizar->getParcela().getfactorNacimiento();
 			CambioARealizar->getParcela().getCelula()->nacer(factorNacimientoParcela, CambioARealizar->getColorPromedio());
-			//this->celulasNacidasTurno ++;
 			this->tableroAsociado->getDatosTablero()->sumarCelulaViva();
 		}
 		else{

--- a/src/TurnoTablero.h
+++ b/src/TurnoTablero.h
@@ -15,8 +15,6 @@
 
 class TurnoTablero{
 private:
-	//unsigned int celulasNacidasTurno;
-	//unsigned int celulasMuertasTurno;
 	Tablero* tableroAsociado;
 	Cola<ParcelaAfectada*> ParcelasAfectadas;
 

--- a/src/TurnoTablero.h
+++ b/src/TurnoTablero.h
@@ -15,8 +15,8 @@
 
 class TurnoTablero{
 private:
-	unsigned int celulasNacidasTurno;
-	unsigned int celulasMuertasTurno;
+	//unsigned int celulasNacidasTurno;
+	//unsigned int celulasMuertasTurno;
 	Tablero* tableroAsociado;
 	Cola<ParcelaAfectada*> ParcelasAfectadas;
 
@@ -56,12 +56,6 @@ private:
 	void decidirVidaOMuerte(int celulasVivasCircundantes, CoordenadaParcela* coordenadaEnCuestion,
 	RGB* coloresCeluasVivasCircundantes[]);
 
-	 /* pre: -
-	 * post: se crea una instancia de la clase turno con un puntero a un tablero pasado
-	 * por parametro
-	 */
-	TurnoTablero(Tablero* tableroAsociado);
-
 	/*
 	 * pre: -
 	 * post: se recorre el tablero asociado a turno parando en cada parcela. para cada parcela
@@ -82,18 +76,13 @@ private:
 	 */
 	void plasmarCambiosEnArchivo();
 
-	/*
-	 * pre: -
-	 * post: se devuelve la cantidad de celulas nacidas en un turno
-	 */
-	unsigned int getNacidasEnTurno();
-	/*
-	 * pre: -
-	 * post: se devuelve la cantidad de celulas muertas en un turno
-	 */
-	unsigned int getMuertasEnTurno();
-
 public:
+
+	 /* pre: -
+	 * post: se crea una instancia de la clase turno con un puntero a un tablero pasado
+	 * por parametro
+	 */
+	TurnoTablero(Tablero* tableroAsociado);
 
 	/*
 	 * pre: -


### PR DESCRIPTION
Se quitan las variables de nacidasEnTurno y muertasEnTuno de TurnoTablero y pasan a DatosTablero. De este modo no perdemos las varables al finalizar la ejecucion de un turnoTablero y tambien contabilizamos las que nacen y mueren en el turno a traves del portal (antes no lo haciamos). Al finalizar la ejecucion del turno en todos los tableros, hay que utilizar el metodo reiniciarContado... para setear a 0 las nacidas y muertas en ultimo turno (antes de esto, habremos usados estas variables para imprimirlas por pantalla)