### PR TITLE
antes, para los portales activos, si una celula que estaba en un port…

### DIFF
--- a/src/Portal.cpp
+++ b/src/Portal.cpp
@@ -40,11 +40,13 @@ void Portal::nacer(RGB* color, float factorNacimientoOrigen) {
 	int fila = this->parcelaAsociada->getCoordenadaX();
 	int columna = this->parcelaAsociada->getCoordenadaY();
 	Tablero * tableroAsociado = this->parcelaAsociada->getTablero();
-	tableroAsociado->getParcela(fila, columna).getCelula()->nacer(
-			factorNacimientoOrigen, color);
-	tableroAsociado->getDatosTablero()->sumarCelulaViva();
-	if (tableroAsociado->getDatosTablero()->estaCongelado()) {
-		tableroAsociado->getDatosTablero()->setCongeladoTurnoActual(false);
+	if (! tableroAsociado->getParcela(fila, columna).getCelula()->getEstado()){
+		tableroAsociado->getParcela(fila, columna).getCelula()->nacer(
+				factorNacimientoOrigen, color);
+		tableroAsociado->getDatosTablero()->sumarCelulaViva();
+		if (tableroAsociado->getDatosTablero()->estaCongelado()) {
+			tableroAsociado->getDatosTablero()->setCongeladoTurnoActual(false);
+		}
 	}
 }
 
@@ -52,13 +54,14 @@ void Portal::morir(float factorMuerteOrigen) {
 	int fila = this->parcelaAsociada->getCoordenadaX();
 	int columna = this->parcelaAsociada->getCoordenadaY();
 	Tablero * tableroAsociado = this->parcelaAsociada->getTablero();
-	bool murio =
-			tableroAsociado->getParcela(fila, columna).getCelula()->restarEnergia(
-					factorMuerteOrigen);
-	if (murio) {
-		tableroAsociado->getDatosTablero()->sumarCelulaMuerta();
-	}
-	if (tableroAsociado->getDatosTablero()->estaCongelado()) {
-		tableroAsociado->getDatosTablero()->setCongeladoTurnoActual(false);
+	if (tableroAsociado->getParcela(fila, columna).getCelula()->getEstado()){
+		bool murio = tableroAsociado->getParcela(fila, columna).getCelula()->restarEnergia(
+						factorMuerteOrigen);
+		if (murio) {
+			tableroAsociado->getDatosTablero()->sumarCelulaMuerta();
+		}
+		if (tableroAsociado->getDatosTablero()->estaCongelado()) {
+			tableroAsociado->getDatosTablero()->setCongeladoTurnoActual(false);
+		}
 	}
 }


### PR DESCRIPTION
la muerte se contaba dos veces. hice el mismo arreglo para los nacimientos porque si no se pueden llegar a contar dos nacimientos cuando solo nace una celula en el tablero